### PR TITLE
feat: remove proveBlock API

### DIFF
--- a/crates/rpc/src/methods.rs
+++ b/crates/rpc/src/methods.rs
@@ -11,12 +11,6 @@ pub trait ScrollSgx {
     #[method(name = "generateAttestationReport")]
     async fn generate_attestation_report(&self) -> Result<String, ErrorObjectOwned>;
 
-    #[method(name = "proveBlock")]
-    async fn prove_block(
-        &self,
-        req: ProveBlockRequest,
-    ) -> Result<ProveBlockResponse, ErrorObjectOwned>;
-
     #[method(name = "proveBatch")]
     async fn prove_batch(
         &self,

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -19,13 +19,6 @@ impl ScrollSgxServer for ScrollSgxServerImpl {
         todo!()
     }
 
-    async fn prove_block(
-        &self,
-        _req: ProveBlockRequest,
-    ) -> Result<ProveBlockResponse, ErrorObjectOwned> {
-        todo!()
-    }
-
     async fn prove_batch(
         &self,
         _req: ProveBatchRequest,

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -4,28 +4,12 @@ use alloy::primitives::{Bytes, Signature, B256};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ProveBlockRequest {
-    prev_state_root: B256,
-    block_trace: BlockTrace,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ProveBlockResponse {
-    post_state_root: B256,
-    post_withdraw_root: B256,
-    signature: Signature,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ProveBatchRequest {
     prev_batch_header: Bytes,
+    prev_state_root: B256,
     batch_version: u8,
     // blocks
     // chunks
-    prev_state_root: B256,
-    state_roots: Vec<B256>,
-    withdraw_roots: Vec<B256>,
-    signatures: Vec<Signature>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -38,6 +22,8 @@ pub struct ProveBatchResponse {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ProveBundleRequest {
+    last_finalized_batch_header: Bytes,
+    prev_state_root: B256,
     batch_headers: Vec<Bytes>,
     state_roots: Vec<B256>,
     withdraw_roots: Vec<B256>,

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -8,8 +8,8 @@ pub struct ProveBatchRequest {
     prev_batch_header: Bytes,
     prev_state_root: B256,
     batch_version: u8,
-    // blocks
-    // chunks
+    blocks: Vec<BlockTrace>,
+    chunks: Vec<Vec<u64>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
After recent discussion with @icemelon, we decided to prove batch-by-batch instead of block-by-block.